### PR TITLE
Update .gitignore to exclude "/resources/sass/.sass-cache"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ bootstrap.*
 ### Compiled Files ###
 build/*
 docs/build/*
-**/.sass-cache/*
+resources/sass/.sass-cache/*
 resources/css/*
 phonegap/*
 native/*


### PR DESCRIPTION
Prior to this commit, the .gitignore file excluded "**/.sass-cache/*"
which failed to match the intended targets. This commit updates the
.gitconfig to explicitly exclude the path
"/resources/sass/.sass-cache" to prevent build materials from getting
committed.